### PR TITLE
Fix to delete process to set rgcreate=true

### DIFF
--- a/installs/install.sh
+++ b/installs/install.sh
@@ -906,6 +906,7 @@ delete )
                     echo "spname to be deleted is: "$spname
                     echo ""
                 else
+                    rgcreate=true
                     echo "the resource group to delete will be: " $resourceGroup
                     echo "spname to be deleted is: "$spname
                     echo ""


### PR DESCRIPTION
Fix to bug causing RG to be left behind on a delete operation due to not setting rgcreate variable to true